### PR TITLE
Set display: none when calendar isn't open

### DIFF
--- a/css/month-picker.css
+++ b/css/month-picker.css
@@ -10,6 +10,8 @@
     -webkit-transition: left 0ms cubic-bezier(0.23, 1, 0.32, 1) 450ms;
     -moz-transition: left 0ms cubic-bezier(0.23, 1, 0.32, 1) 450ms;
     transition: left 0ms cubic-bezier(0.23, 1, 0.32, 1) 450ms; }
+  .month-picker > .rmp-container:not(.show) {
+    display: none; }
     @media screen and (max-width: 767px) {
       .month-picker > .rmp-container {
         position: fixed;


### PR DESCRIPTION
This prevents errors in height detection by bootstrap collapse component