### PR TITLE
Fix Sass division deprecation warning

### DIFF
--- a/scss/month-picker.scss
+++ b/scss/month-picker.scss
@@ -90,10 +90,10 @@
     $option-height: 3.4rem;
     $mon-pad-width: 20rem;
     $mon-pad-cols: 3;
-    $mon-pad-rows: math.div(12, $mon-pad-cols);
+    $mon-pad-rows: round(math.div(12, $mon-pad-cols));
     $mon-option-width: math.div(100%, $mon-pad-cols);
     $m-mon-pad-cols: 4;
-    $m-mon-pad-rows: math.div(12, $m-mon-pad-cols);
+    $m-mon-pad-rows: round(math.div(12, $m-mon-pad-cols));
     $m-mon-option-width: math.div(100%, $m-mon-pad-cols);
 
     $popup-pad: 0.4rem;

--- a/scss/month-picker.scss
+++ b/scss/month-picker.scss
@@ -90,11 +90,11 @@
     $option-height: 3.4rem;
     $mon-pad-width: 20rem;
     $mon-pad-cols: 3;
-    $mon-pad-rows: round(12 / $mon-pad-cols);
-    $mon-option-width: 100% / $mon-pad-cols;
+    $mon-pad-rows: math.div(12, $mon-pad-cols);
+    $mon-option-width: math.div(100%, $mon-pad-cols);
     $m-mon-pad-cols: 4;
-    $m-mon-pad-rows: round(12 / $m-mon-pad-cols);
-    $m-mon-option-width: 100% / $m-mon-pad-cols;
+    $m-mon-pad-rows: math.div(12, $m-mon-pad-cols);
+    $m-mon-option-width: math.div(100%, $m-mon-pad-cols);
 
     $popup-pad: 0.4rem;
     $pad-head-height: 3.4rem;


### PR DESCRIPTION
I am getting console warnings (copied below) when importing this project's SCSS file into my next.js project.

> Sass currently treats / as a division operation in some contexts and a separator in others. This makes it difficult for Sass users to tell what any given / will mean, and makes it hard to work with new CSS features that use / as a separator.

[Sass docs](https://sass-lang.com/documentation/breaking-changes/slash-div)

I've made these changes to hopefully remove this deprecated feature and fix these warnings.

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(12, $mon-pad-cols)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
93 │     $mon-pad-rows: round(12 / $mon-pad-cols);
   │                          ^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/react-month-picker/scss/month-picker.scss 93:26  root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(100%, $mon-pad-cols)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
94 │     $mon-option-width: 100% / $mon-pad-cols;
   │                        ^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/react-month-picker/scss/month-picker.scss 94:24  root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(12, $m-mon-pad-cols)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
96 │     $m-mon-pad-rows: round(12 / $m-mon-pad-cols);
   │                            ^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/react-month-picker/scss/month-picker.scss 96:28  root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(100%, $m-mon-pad-cols)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
97 │     $m-mon-option-width: 100% / $m-mon-pad-cols;
   │                          ^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/react-month-picker/scss/month-picker.scss 97:26  root stylesheet
```